### PR TITLE
adjust the center of anim

### DIFF
--- a/fab-transformation/src/main/java/com/konifar/fab_transformation/animation/FabAnimator.java
+++ b/fab-transformation/src/main/java/com/konifar/fab_transformation/animation/FabAnimator.java
@@ -125,86 +125,24 @@ public abstract class FabAnimator {
         });
     }
 
-    int getCenterX(View fab, View transformView) {
-        int translationX = getTranslationX(fab, transformView);
-        return ViewUtil.getRelativeLeft(fab) - ViewUtil.getRelativeLeft(transformView) + fab.getWidth() / 2 + translationX;
+    int getCenterX(View view) {
+        return view.getWidth() / 2 + view.getLeft();
     }
 
-    int getCenterY(View fab, View transformView) {
-        int translationY = getTranslationY(fab, transformView);
-        return ViewUtil.getRelativeTop(fab) - ViewUtil.getRelativeTop(transformView) + fab.getHeight() / 2 + translationY;
+    int getCenterY(View view) {
+        return view.getHeight() / 2 + view.getTop();
     }
 
     int getTranslationX(View fab, View transformView) {
-        int fabWidth = fab.getWidth();
-        int fabLeft = ViewUtil.getRelativeLeft(fab);
-        int fabRight = fabLeft + fabWidth;
-        int fabCenterX = fabLeft + fabWidth / 2;
-        int transformViewWidth = transformView.getWidth();
-        int transformViewLeft = ViewUtil.getRelativeLeft(transformView);
-        int transformViewRight = transformViewLeft + transformViewWidth;
-        int transformViewCenterX = transformViewLeft + transformViewWidth / 2;
-
-        if (fabCenterX > transformViewCenterX) {
-            // Fab is on right of transform view
-            int translationX = transformViewCenterX - fabCenterX;
-            if (-translationX >= fabWidth) {
-                translationX = -fabWidth;
-            }
-            if (-translationX < fabRight - transformViewRight) {
-                translationX = -(fabRight - transformViewRight + fabWidth / 2);
-            }
-            return translationX;
-        } else if (fabCenterX < transformViewCenterX) {
-            // Fab is on left of transform view
-            int translationX = transformViewCenterX - fabCenterX;
-            if (translationX >= fabWidth) {
-                translationX = fabWidth;
-            }
-            if (translationX > transformViewLeft - fabLeft) {
-                translationX = transformViewLeft - fabLeft + fabWidth / 2;
-            }
-            return translationX;
-        } else {
-            // Fab is same position with transform view
-            return 0;
-        }
+        int fabX = ViewUtil.getRelativeLeft(fab) + fab.getWidth() / 2;
+        int transformViewX = ViewUtil.getRelativeLeft(transformView) + transformView.getWidth() / 2;
+        return transformViewX - fabX;
     }
 
     int getTranslationY(View fab, View transformView) {
-        int fabHeight = fab.getHeight();
-        int fabTop = ViewUtil.getRelativeTop(fab);
-        int fabBottom = fabTop + fabHeight;
-        int fabCenterY = fabTop + fabHeight / 2;
-        int transformViewHeight = transformView.getHeight();
-        int transformViewTop = ViewUtil.getRelativeTop(transformView);
-        int transformViewBottom = transformViewTop + transformViewHeight;
-        int transformViewCenterY = transformViewTop + transformViewHeight / 2;
-
-        if (fabCenterY > transformViewCenterY) {
-            // Fab is on below of transform view
-            int translationY = transformViewCenterY - fabCenterY;
-            if (-translationY >= fabHeight / 8) {
-                translationY = -fabHeight / 8;
-            }
-            if (-translationY < fabBottom - transformViewBottom) {
-                translationY = -(fabBottom - transformViewBottom);
-            }
-            return translationY;
-        } else if (fabCenterY < transformViewCenterY) {
-            // Fab is on above of transform view
-            int translationY = transformViewCenterY - fabCenterY;
-            if (translationY >= fabHeight / 8) {
-                translationY = fabHeight / 8;
-            }
-            if (translationY < transformViewTop - fabTop) {
-                translationY = transformViewTop - fabTop;
-            }
-            return translationY;
-        } else {
-            // Fab is same position with transform view
-            return 0;
-        }
+        int fabY = ViewUtil.getRelativeTop(fab) + fab.getHeight() / 2;
+        int transformViewY = ViewUtil.getRelativeTop(transformView) + transformView.getHeight() / 2;
+        return transformViewY - fabY;
     }
 
     interface RevealCallback {

--- a/fab-transformation/src/main/java/com/konifar/fab_transformation/animation/FabAnimatorLollipop.java
+++ b/fab-transformation/src/main/java/com/konifar/fab_transformation/animation/FabAnimatorLollipop.java
@@ -14,8 +14,8 @@ public class FabAnimatorLollipop extends FabAnimator {
     final void revealOff(final View fab, final View transformView, final RevealCallback callback) {
         Animator animator = ViewAnimationUtils.createCircularReveal(
                 transformView,
-                getCenterX(fab, transformView),
-                getCenterY(fab, transformView),
+                getCenterX(transformView),
+                getCenterY(transformView),
                 (float) Math.hypot(transformView.getWidth(), transformView.getHeight()) / 2,
                 fab.getWidth() / 2);
         animator.setInterpolator(REVEAL_INTERPOLATOR);
@@ -52,8 +52,8 @@ public class FabAnimatorLollipop extends FabAnimator {
     final void revealOn(final View fab, View transformView, final RevealCallback callback) {
         Animator animator = ViewAnimationUtils.createCircularReveal(
                 transformView,
-                getCenterX(fab, transformView),
-                getCenterY(fab, transformView),
+                getCenterX(transformView),
+                getCenterY(transformView),
                 fab.getWidth() / 2,
                 (float) Math.hypot(transformView.getWidth(), transformView.getHeight()) / 2);
         transformView.setVisibility(View.VISIBLE);

--- a/fab-transformation/src/main/java/com/konifar/fab_transformation/animation/FabAnimatorPreL.java
+++ b/fab-transformation/src/main/java/com/konifar/fab_transformation/animation/FabAnimatorPreL.java
@@ -16,8 +16,8 @@ public class FabAnimatorPreL extends FabAnimator {
     final void revealOff(final View fab, final View transformView, final RevealCallback callback) {
         SupportAnimator animator = ViewAnimationUtils.createCircularReveal(
                 transformView,
-                getCenterX(fab, transformView),
-                getCenterY(fab, transformView),
+                getCenterX(fab),
+                getCenterY(fab),
                 (float) Math.hypot(transformView.getWidth(), transformView.getHeight()) / 2,
                 fab.getWidth() / 2);
         animator.setInterpolator(REVEAL_INTERPOLATOR);
@@ -54,8 +54,8 @@ public class FabAnimatorPreL extends FabAnimator {
     final void revealOn(final View fab, final View transformView, final RevealCallback callback) {
         SupportAnimator animator = ViewAnimationUtils.createCircularReveal(
                 transformView,
-                getCenterX(fab, transformView),
-                getCenterY(fab, transformView),
+                getCenterX(fab),
+                getCenterY(fab),
                 fab.getWidth() / 2,
                 (float) Math.hypot(transformView.getWidth(), transformView.getHeight()) / 2);
         transformView.setVisibility(View.VISIBLE);

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 01 17:04:27 JST 2015
+#Tue Nov 29 21:12:05 CST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
# Smoother animation 

Hello, I have used your animation library, but I found the animation is a bit stiff, and fab's revealOn animation can not make transformView all covered out. So, I think of a way, is to revealOn center placed in the center of transformView, so that the animation transition is smoother. You can look at my code, I hope to be able to adopt, thank you.


你好，我已经使用过你的动画库了，但是我发现你的动画有点僵直，而且fab的revealOn动画不能把transformView全部覆盖掉。所以，我想了一个方法，就是把revealOn的中心放置在transformView的中心，从而使这个动画过渡更加平滑了。你可以看一下我的代码，希望能够采纳，谢谢你。